### PR TITLE
Updates to appveyor setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,6 @@ artifacts:
 
   - path: '\*_*.zip'
     name: Bits
+
+environment:
+  R_VERSION: 3.4.4

--- a/tests/testthat/test-calendar.R
+++ b/tests/testthat/test-calendar.R
@@ -421,7 +421,7 @@ test_that("it should export a calendar", {
   cal <- calendars()[["weekends"]]
   con <- tempfile(fileext = ".json")
   save_calendar(cal, con)
-  expect_equal(cnt, readChar(con, 1024*1024))
+  expect_equal(cnt, gsub("\r", "", readChar(con, 1024*1024)))
   cnt <- '{
   "name": "actual",
   "financial": true
@@ -429,7 +429,7 @@ test_that("it should export a calendar", {
 '
   con <- tempfile(fileext = ".json")
   save_calendar("actual", con)
-  expect_equal(cnt, readChar(con, 1024*1024))
+  expect_equal(cnt, gsub("\r", "", readChar(con, 1024*1024)))
 })
 
 test_that("it should import a calendar", {


### PR DESCRIPTION
Set R_VERSION to 3.4.4 because of RQuantLib.
This package is no available in 3.5.

The test-calendar has been updated because of problems with EOF in text comparisons.
The \r char has been removed, so except for a \r char, the tests are ok.

Now appveyor is passing