### PR TITLE
Added financial argument to others calendars functions

### DIFF
--- a/R/create-calendars.R
+++ b/R/create-calendars.R
@@ -11,6 +11,8 @@
 #' @param to (QuantLib only) the end date
 #' @param year (timeDate Rmetrics only) a vector with years to create the 
 #' calendars.
+#' @param financial is a logical argument that defaults to TRUE.
+#' 
 #' 
 #' @details
 #' To load QuantLib's calendars use \code{load_quantlib_calendars} defining 
@@ -22,6 +24,12 @@
 #' To load Rmetrics' calendars use \code{load_rmetrics_calendars} defining the 
 #' years the calendar has to handle.
 #' All Rmetrics calendars have the \code{Rmetrics} prefix.
+#' 
+#' @section Financial calendars:
+#' 
+#' This argument defines the calendar as a financial or a non financial calendar.
+#' Financial calendars don't consider the ending business day when counting working days in \code{bizdays}.
+#' In QuantLib, Financial calendars are those that \code{includeLast} is set to \code{FALSE}.
 #' 
 #' @section List of calendars:
 #' 
@@ -129,7 +137,8 @@ local({
 
 #' @rdname other-calendars
 #' @export
-load_quantlib_calendars <- function(ql_calendars = NULL, from, to) {
+load_quantlib_calendars <- function(ql_calendars = NULL, from, to,
+                                    financial = TRUE) {
   if (!requireNamespace("RQuantLib", quietly = TRUE)) {
     stop("RQuantLib needed for this function to work. Please install it.",
          call. = FALSE)
@@ -161,14 +170,15 @@ load_quantlib_calendars <- function(ql_calendars = NULL, from, to) {
     create.calendar(holidays_, weekdays = c('saturday', 'sunday'),
                     name = cal_name,
                     start.date = from, end.date = to,
-                    adjust.from = adjust.next, adjust.to = adjust.next)
+                    adjust.from = adjust.next, adjust.to = adjust.next,
+                    financial = financial)
     message("Calendar ", cal_name, " loaded")
   }
 }
 
 #' @rdname other-calendars
 #' @export
-load_rmetrics_calendars <- function(year) {
+load_rmetrics_calendars <- function(year, financial = TRUE) {
   if (!requireNamespace("timeDate", quietly = TRUE)) {
     stop("timeDate needed for this function to work. Please install it.",
          call. = FALSE)
@@ -183,7 +193,8 @@ load_rmetrics_calendars <- function(year) {
   create.calendar(holidays_, weekdays = c('saturday', 'sunday'),
                   name = cal_name,
                   adjust.from = adjust.next, adjust.to = adjust.previous,
-                  start.date = start_date, end.date = end_date)
+                  start.date = start_date, end.date = end_date,
+                  financial = financial)
   message("Calendar ", cal_name, " loaded")
 
   holidays_ <- as.Date(timeDate::holidayNERC(year))

--- a/tests/testthat/test-calendar.R
+++ b/tests/testthat/test-calendar.R
@@ -347,6 +347,19 @@ if (requireNamespace("RQuantLib", quietly = TRUE)) {
     expect_equal(bizdays('2016-01-01', '2016-07-10',
                          'QuantLib/UnitedStates/NYSE'), ql_bd)
   })
+  
+  test_that('it should compare bizdays calendar with RQuantLib calendars', {
+    load_quantlib_calendars('UnitedStates',
+                            from = '1996-01-01', to = '2040-12-31',
+                            financial = FALSE)
+    x <- bizdays('2020-01-01', '2020-12-31', 'QuantLib/UnitedStates')
+    y <- RQuantLib::businessDaysBetween(calendar = "UnitedStates",
+                                   from = as.Date("2020-01-01"),
+                                   to = as.Date("2020-12-31"),
+                                   includeFirst = TRUE,
+                                   includeLast = TRUE)
+    expect_equal(x, y)
+  })
 }
 
 if (requireNamespace("timeDate", quietly = TRUE)) {


### PR DESCRIPTION
load_quantlib_calendars and load_rmetrics_calendars have a financial argument to define if the loaded calendar is a financial calendar.

This solves the Issue #86.