### PR TITLE
docs: link pkgdown URL from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Business days calculations based on a list of holidays and
 Version: 1.0.16
 Author: Wilson Freitas <wilson.freitas@gmail.com>
 Maintainer: Wilson Freitas <wilson.freitas@gmail.com>
-URL: https://github.com/wilsonfreitas/R-bizdays
+URL: https://github.com/wilsonfreitas/R-bizdays, http://wilsonfreitas.github.io/R-bizdays/
 VignetteBuilder: knitr
 Suggests: 
     RQuantLib,


### PR DESCRIPTION
To make it easier to find from the CRAN page for instance. :smile_cat: 